### PR TITLE
[#80] 배치 작업 종료 시 애플리케이션도 함께 종료되도록 수정

### DIFF
--- a/batch/src/main/kotlin/com/doyoumate/batch/BatchApplication.kt
+++ b/batch/src/main/kotlin/com/doyoumate/batch/BatchApplication.kt
@@ -1,13 +1,15 @@
 package com.doyoumate.batch
 
+import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.ComponentScan
+import kotlin.system.exitProcess
 
 @ComponentScan("com.doyoumate.batch", "com.doyoumate.domain", "com.doyoumate.common")
 @SpringBootApplication
 class BatchApplication
 
 fun main(args: Array<String>) {
-    runApplication<BatchApplication>(*args)
+    exitProcess(SpringApplication.exit(runApplication<BatchApplication>(*args)))
 }


### PR DESCRIPTION
## 작업 내용

* **배치 작업 종료 시 Exit Code와 함께 애플리케이션이 종료되도록 수정**

## 코멘트

* 배치 작업을 Kubernetes의 CronJob과 함께 사용하기 위해 수행한 PR

## 관련 이슈

* **Close #80**